### PR TITLE
Feature/api migration and personal mode

### DIFF
--- a/src/api/allowedUsers.api.ts
+++ b/src/api/allowedUsers.api.ts
@@ -2,12 +2,14 @@ import config from '@app/config/config';
 import { readToken } from '@app/services/localStorage.service';
 import {
   AllowedUsersSettings,
-  AllowedUsersApiResponse,
-  AllowedUsersNpubsResponse,
-  BulkImportRequest,
-  AllowedUsersNpub,
+  AllowedUsersResponse,
+  AddAllowedUserRequest,
+  RemoveAllowedUserRequest,
+  ApiResponse,
   AllowedUsersMode,
-  DEFAULT_TIERS
+  DEFAULT_TIERS,
+  RelayOwnerResponse,
+  SetRelayOwnerRequest
 } from '@app/types/allowedUsers.types';
 
 // Settings Management
@@ -45,28 +47,15 @@ export const getAllowedUsersSettings = async (): Promise<AllowedUsersSettings> =
     } else {
       // Use default tiers for the mode if none provided
       const mode = allowedUsersData.mode as AllowedUsersMode;
-      transformedTiers = DEFAULT_TIERS[mode] || DEFAULT_TIERS.free;
-    }
-
-    // For free mode, reconstruct full UI options with active tier marked
-    if (allowedUsersData.mode === 'free' && transformedTiers.length === 1) {
-      const activeTierBytes = transformedTiers[0].monthly_limit_bytes;
-      transformedTiers = DEFAULT_TIERS.free.map(defaultTier => ({
-        ...defaultTier,
-        active: defaultTier.monthly_limit_bytes === activeTierBytes
-      }));
-    }
-    
-    // For personal mode, reconstruct with single unlimited tier
-    if (allowedUsersData.mode === 'personal' && transformedTiers.length === 1) {
-      transformedTiers = DEFAULT_TIERS.personal;
+      transformedTiers = DEFAULT_TIERS[mode] || DEFAULT_TIERS['public'];
     }
     
     const transformedSettings = {
-      mode: allowedUsersData.mode || 'free',
-      read_access: allowedUsersData.read_access || { enabled: true, scope: 'all_users' },
-      write_access: allowedUsersData.write_access || { enabled: true, scope: 'all_users' },
-      tiers: transformedTiers
+      mode: allowedUsersData.mode || 'public',
+      read: allowedUsersData.read || 'all_users',
+      write: allowedUsersData.write || 'all_users',
+      tiers: transformedTiers,
+      relay_owner_npub: allowedUsersData.relay_owner_npub || ''
     };
     
     return transformedSettings;
@@ -75,37 +64,46 @@ export const getAllowedUsersSettings = async (): Promise<AllowedUsersSettings> =
   }
 };
 
-export const updateAllowedUsersSettings = async (settings: AllowedUsersSettings): Promise<{ success: boolean, message: string }> => {
+export const updateAllowedUsersSettings = async (settings: AllowedUsersSettings): Promise<ApiResponse> => {
   const token = readToken();
   
-  // Filter tiers based on mode - for free and personal modes, only send active tier
-  const tiersToSend = (settings.mode === 'free' || settings.mode === 'personal')
-    ? settings.tiers.filter(tier => tier.active)
-    : settings.tiers;
-  
   // Transform to nested format as expected by new unified backend API
+  // Note: relay_owner_npub is no longer sent in settings - it's managed via /api/allowed-users
   const nestedSettings = {
     "settings": {
       "allowed_users": {
         "mode": settings.mode,
-        "read_access": {
-          "enabled": settings.read_access.enabled,
-          "scope": settings.read_access.scope
-        },
-        "write_access": {
-          "enabled": settings.write_access.enabled,
-          "scope": settings.write_access.scope
-        },
-        "tiers": tiersToSend.map(tier => ({
-          "name": tier.name,
-          "price_sats": tier.price_sats,
-          "monthly_limit_bytes": tier.monthly_limit_bytes,
-          "unlimited": tier.unlimited
-        }))
+        "read": settings.read,
+        "write": settings.write,
+        "tiers": settings.mode === 'public' 
+          ? settings.tiers.filter(tier => tier.active).map(tier => ({
+              "name": tier.name,
+              "price_sats": tier.price_sats,
+              "monthly_limit_bytes": tier.monthly_limit_bytes,
+              "unlimited": tier.unlimited
+            }))
+          : settings.tiers.map(tier => ({
+              "name": tier.name,
+              "price_sats": tier.price_sats,
+              "monthly_limit_bytes": tier.monthly_limit_bytes,
+              "unlimited": tier.unlimited
+            }))
       }
     }
   };
   
+  // Comprehensive logging for debugging
+  console.group('🔧 [API] Updating Allowed Users Settings');
+  console.log('📤 Original frontend settings:', settings);
+  console.log('📦 Transformed payload for backend:', nestedSettings);
+  console.log('🎯 Mode being sent:', settings.mode);
+  console.log('📖 Read permission:', settings.read);
+  console.log('✍️ Write permission:', settings.write);
+  console.log('🏷️ Number of tiers:', settings.tiers.length);
+  console.log('📋 Tiers details:', settings.tiers);
+  console.log('🌐 Request URL:', `${config.baseURL}/api/settings`);
+  console.log('📄 Request body (stringified):', JSON.stringify(nestedSettings, null, 2));
+  console.groupEnd();
   
   const response = await fetch(`${config.baseURL}/api/settings`, {
     method: 'POST',
@@ -118,22 +116,38 @@ export const updateAllowedUsersSettings = async (settings: AllowedUsersSettings)
   
   const text = await response.text();
   
+  // Log response details
+  console.group('📥 [API] Settings Update Response');
+  console.log('📊 Response status:', response.status);
+  console.log('✅ Response OK:', response.ok);
+  console.log('📄 Response text:', text);
+  console.groupEnd();
+  
   if (!response.ok) {
+    console.error('❌ [API] Settings update failed:', {
+      status: response.status,
+      statusText: response.statusText,
+      responseText: text,
+      sentPayload: nestedSettings
+    });
     throw new Error(`HTTP error! status: ${response.status}, response: ${text}`);
   }
   
   try {
-    return JSON.parse(text) || { success: true, message: 'Settings updated successfully' };
+    const parsedResponse = JSON.parse(text);
+    console.log('✅ [API] Settings update successful:', parsedResponse);
+    return parsedResponse;
   } catch (jsonError) {
     // If response is not JSON, assume success if status was OK
+    console.log('ℹ️ [API] Non-JSON response, assuming success');
     return { success: true, message: 'Settings updated successfully' };
   }
 };
 
-// Read NPUBs Management
-export const getReadNpubs = async (page = 1, pageSize = 20): Promise<AllowedUsersNpubsResponse> => {
+// Unified User Management - Direct API calls (no fallback needed)
+export const getAllowedUsers = async (page = 1, pageSize = 20): Promise<AllowedUsersResponse> => {
   const token = readToken();
-  const response = await fetch(`${config.baseURL}/api/allowed-npubs/read?page=${page}&pageSize=${pageSize}`, {
+  const response = await fetch(`${config.baseURL}/api/allowed-users?page=${page}&pageSize=${pageSize}`, {
     headers: {
       'Authorization': `Bearer ${token}`,
     },
@@ -144,35 +158,80 @@ export const getReadNpubs = async (page = 1, pageSize = 20): Promise<AllowedUser
   const text = await response.text();
   try {
     const data = JSON.parse(text);
-    // Transform backend response to expected format - map tier_name to tier
-    const transformedNpubs = (data.npubs || []).map((npub: any) => ({
-      ...npub,
-      tier: npub.tier_name || npub.tier || 'basic'
-    }));
     
     return {
-      npubs: transformedNpubs,
-      total: data.pagination?.total || 0,
-      page: data.pagination?.page || page,
-      pageSize: data.pagination?.pageSize || pageSize
+      allowed_users: data.allowed_users || [],
+      pagination: data.pagination || {
+        page: page,
+        page_size: pageSize,
+        total_pages: 1,
+        total_items: 0
+      }
     };
   } catch (jsonError) {
     throw new Error(`Invalid JSON response: ${text}`);
   }
 };
 
-export const addReadNpub = async (npub: string, tier: string): Promise<{ success: boolean, message: string }> => {
+export const addAllowedUser = async (request: AddAllowedUserRequest): Promise<ApiResponse> => {
   const token = readToken();
-  const requestBody = { npub, tier };
   
+  // Comprehensive logging for user addition
+  console.group('👤 [API] Adding Allowed User');
+  console.log('📤 Request payload:', request);
+  console.log('🌐 Request URL:', `${config.baseURL}/api/allowed-users`);
+  console.log('📄 Request body (stringified):', JSON.stringify(request, null, 2));
+  console.log('🔑 Authorization token present:', !!token);
+  console.groupEnd();
   
-  const response = await fetch(`${config.baseURL}/api/allowed-npubs/read`, {
+  const response = await fetch(`${config.baseURL}/api/allowed-users`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${token}`,
     },
-    body: JSON.stringify(requestBody),
+    body: JSON.stringify(request),
+  });
+  
+  const text = await response.text();
+  
+  // Log response details
+  console.group('📥 [API] Add User Response');
+  console.log('📊 Response status:', response.status);
+  console.log('✅ Response OK:', response.ok);
+  console.log('📄 Response text:', text);
+  console.groupEnd();
+  
+  if (!response.ok) {
+    console.error('❌ [API] Add user failed:', {
+      status: response.status,
+      statusText: response.statusText,
+      responseText: text,
+      sentPayload: request
+    });
+    throw new Error(`HTTP error! status: ${response.status}, response: ${text}`);
+  }
+  
+  try {
+    const parsedResponse = JSON.parse(text);
+    console.log('✅ [API] Add user successful:', parsedResponse);
+    return parsedResponse;
+  } catch (jsonError) {
+    console.log('ℹ️ [API] Non-JSON response, assuming success');
+    return { success: true, message: 'User added successfully' };
+  }
+};
+
+export const removeAllowedUser = async (request: RemoveAllowedUserRequest): Promise<ApiResponse> => {
+  const token = readToken();
+  
+  const response = await fetch(`${config.baseURL}/api/allowed-users`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify(request),
   });
   
   if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
@@ -185,9 +244,89 @@ export const addReadNpub = async (npub: string, tier: string): Promise<{ success
   }
 };
 
-export const removeReadNpub = async (npub: string): Promise<{ success: boolean, message: string }> => {
+// Relay Owner Management API (for only-me mode)
+export const getRelayOwner = async (): Promise<RelayOwnerResponse> => {
   const token = readToken();
-  const response = await fetch(`${config.baseURL}/api/allowed-npubs/read/${npub}`, {
+  
+  console.group('🔍 [API] Getting Relay Owner');
+  console.log('🌐 Request URL:', `${config.baseURL}/api/admin/owner`);
+  console.log('🔑 Authorization token present:', !!token);
+  console.groupEnd();
+  
+  const response = await fetch(`${config.baseURL}/api/admin/owner`, {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+    },
+  });
+  
+  const text = await response.text();
+  
+  console.group('📥 [API] Get Owner Response');
+  console.log('📊 Response status:', response.status);
+  console.log('✅ Response OK:', response.ok);
+  console.log('📄 Response text:', text);
+  console.groupEnd();
+  
+  if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+  
+  try {
+    const parsedResponse = JSON.parse(text);
+    console.log('✅ [API] Get owner successful:', parsedResponse);
+    return parsedResponse;
+  } catch (jsonError) {
+    throw new Error(`Invalid JSON response: ${text}`);
+  }
+};
+
+export const setRelayOwner = async (request: SetRelayOwnerRequest): Promise<ApiResponse> => {
+  const token = readToken();
+  
+  console.group('👤 [API] Setting Relay Owner');
+  console.log('📤 Request payload:', request);
+  console.log('🌐 Request URL:', `${config.baseURL}/api/admin/owner`);
+  console.groupEnd();
+  
+  const response = await fetch(`${config.baseURL}/api/admin/owner`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify(request),
+  });
+  
+  const text = await response.text();
+  
+  console.group('📥 [API] Set Owner Response');
+  console.log('📊 Response status:', response.status);
+  console.log('✅ Response OK:', response.ok);
+  console.log('📄 Response text:', text);
+  console.groupEnd();
+  
+  if (!response.ok) {
+    console.error('❌ [API] Set owner failed:', {
+      status: response.status,
+      statusText: response.statusText,
+      responseText: text,
+      sentPayload: request
+    });
+    throw new Error(`HTTP error! status: ${response.status}, response: ${text}`);
+  }
+  
+  try {
+    const parsedResponse = JSON.parse(text);
+    console.log('✅ [API] Set owner successful:', parsedResponse);
+    return parsedResponse;
+  } catch (jsonError) {
+    console.log('ℹ️ [API] Non-JSON response, assuming success');
+    return { success: true, message: 'Relay owner set successfully' };
+  }
+};
+
+export const removeRelayOwner = async (): Promise<ApiResponse> => {
+  const token = readToken();
+  
+  const response = await fetch(`${config.baseURL}/api/admin/owner`, {
     method: 'DELETE',
     headers: {
       'Authorization': `Bearer ${token}`,
@@ -198,104 +337,9 @@ export const removeReadNpub = async (npub: string): Promise<{ success: boolean, 
   
   const text = await response.text();
   try {
-    return JSON.parse(text);
+    const parsedResponse = JSON.parse(text);
+    return parsedResponse;
   } catch (jsonError) {
-    throw new Error(`Invalid JSON response: ${text}`);
-  }
-};
-
-// Write NPUBs Management
-export const getWriteNpubs = async (page = 1, pageSize = 20): Promise<AllowedUsersNpubsResponse> => {
-  const token = readToken();
-  const response = await fetch(`${config.baseURL}/api/allowed-npubs/write?page=${page}&pageSize=${pageSize}`, {
-    headers: {
-      'Authorization': `Bearer ${token}`,
-    },
-  });
-  
-  if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-  
-  const text = await response.text();
-  try {
-    const data = JSON.parse(text);
-    // Transform backend response to expected format - map tier_name to tier
-    const transformedNpubs = (data.npubs || []).map((npub: any) => ({
-      ...npub,
-      tier: npub.tier_name || npub.tier || 'basic'
-    }));
-    
-    return {
-      npubs: transformedNpubs,
-      total: data.pagination?.total || 0,
-      page: data.pagination?.page || page,
-      pageSize: data.pagination?.pageSize || pageSize
-    };
-  } catch (jsonError) {
-    throw new Error(`Invalid JSON response: ${text}`);
-  }
-};
-
-export const addWriteNpub = async (npub: string, tier: string): Promise<{ success: boolean, message: string }> => {
-  const token = readToken();
-  const requestBody = { npub, tier };
-  
-  
-  const response = await fetch(`${config.baseURL}/api/allowed-npubs/write`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`,
-    },
-    body: JSON.stringify(requestBody),
-  });
-  
-  if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-  
-  const text = await response.text();
-  try {
-    return JSON.parse(text);
-  } catch (jsonError) {
-    throw new Error(`Invalid JSON response: ${text}`);
-  }
-};
-
-export const removeWriteNpub = async (npub: string): Promise<{ success: boolean, message: string }> => {
-  const token = readToken();
-  const response = await fetch(`${config.baseURL}/api/allowed-npubs/write/${npub}`, {
-    method: 'DELETE',
-    headers: {
-      'Authorization': `Bearer ${token}`,
-    },
-  });
-  
-  if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-  
-  const text = await response.text();
-  try {
-    return JSON.parse(text);
-  } catch (jsonError) {
-    throw new Error(`Invalid JSON response: ${text}`);
-  }
-};
-
-// Bulk Import
-export const bulkImportNpubs = async (importData: BulkImportRequest): Promise<{ success: boolean, message: string, imported: number, failed: number }> => {
-  const token = readToken();
-  const response = await fetch(`${config.baseURL}/api/allowed-npubs/bulk-import`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`,
-    },
-    body: JSON.stringify(importData),
-  });
-  
-  if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-  
-  const text = await response.text();
-  try {
-    return JSON.parse(text);
-  } catch (jsonError) {
-    throw new Error(`Invalid JSON response: ${text}`);
+    return { success: true, message: 'Relay owner removed successfully' };
   }
 };

--- a/src/api/allowedUsers.api.ts
+++ b/src/api/allowedUsers.api.ts
@@ -144,10 +144,10 @@ export const updateAllowedUsersSettings = async (settings: AllowedUsersSettings)
   }
 };
 
-// Unified User Management - Direct API calls (no fallback needed)
+// Unified User Management - Using correct invite-only endpoints
 export const getAllowedUsers = async (page = 1, pageSize = 20): Promise<AllowedUsersResponse> => {
   const token = readToken();
-  const response = await fetch(`${config.baseURL}/api/allowed-users?page=${page}&pageSize=${pageSize}`, {
+  const response = await fetch(`${config.baseURL}/api/allowed/users?page=${page}&pageSize=${pageSize}`, {
     headers: {
       'Authorization': `Bearer ${token}`,
     },
@@ -176,15 +176,16 @@ export const getAllowedUsers = async (page = 1, pageSize = 20): Promise<AllowedU
 export const addAllowedUser = async (request: AddAllowedUserRequest): Promise<ApiResponse> => {
   const token = readToken();
   
-  // Comprehensive logging for user addition
+  // Backend expects NPUB format (not hex), so keep as-is
   console.group('👤 [API] Adding Allowed User');
   console.log('📤 Request payload:', request);
-  console.log('🌐 Request URL:', `${config.baseURL}/api/allowed-users`);
+  console.log('🌐 Request URL:', `${config.baseURL}/api/allowed/add`);
   console.log('📄 Request body (stringified):', JSON.stringify(request, null, 2));
   console.log('🔑 Authorization token present:', !!token);
   console.groupEnd();
   
-  const response = await fetch(`${config.baseURL}/api/allowed-users`, {
+  // Using correct POST method with request body
+  const response = await fetch(`${config.baseURL}/api/allowed/add`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -225,7 +226,8 @@ export const addAllowedUser = async (request: AddAllowedUserRequest): Promise<Ap
 export const removeAllowedUser = async (request: RemoveAllowedUserRequest): Promise<ApiResponse> => {
   const token = readToken();
   
-  const response = await fetch(`${config.baseURL}/api/allowed-users`, {
+  // Using correct DELETE method with request body
+  const response = await fetch(`${config.baseURL}/api/allowed/remove`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',

--- a/src/components/allowed-users/components/ModeSelector/ModeSelector.tsx
+++ b/src/components/allowed-users/components/ModeSelector/ModeSelector.tsx
@@ -10,25 +10,25 @@ interface ModeSelectorProps {
 }
 
 const MODE_INFO = {
-  personal: {
+  'only-me': {
     label: 'Only Me',
     subtitle: '[Free]',
     description: 'Personal relay for single user with unlimited access',
     color: '#fa541c'
   },
-  exclusive: {
+  'invite-only': {
     label: 'Invite Only',
     subtitle: '[Free]',
     description: 'Invite-only access with manual NPUB management',
     color: '#722ed1'
   },
-  free: {
+  'public': {
     label: 'Public Relay',
     subtitle: '[Free]',
     description: 'Open access with optional free tiers',
     color: '#1890ff'
   },
-  paid: {
+  'subscription': {
     label: 'Subscription',
     subtitle: '[Paid]',
     description: 'Subscription-based access control',
@@ -44,7 +44,7 @@ export const ModeSelector: React.FC<ModeSelectorProps> = ({
   return (
     <S.Container>
       <S.ModeGrid>
-        {(['personal', 'exclusive', 'free', 'paid'] as AllowedUsersMode[]).map((mode) => {
+        {(['only-me', 'invite-only', 'public', 'subscription'] as AllowedUsersMode[]).map((mode) => {
           const info = MODE_INFO[mode];
           const isActive = currentMode === mode;
           
@@ -76,7 +76,7 @@ export const ModeSelector: React.FC<ModeSelectorProps> = ({
       
       <S.ModeDescription>
         <S.DescriptionText>
-          <strong>{MODE_INFO[currentMode].label}:</strong> {MODE_INFO[currentMode].description}
+          <strong>{MODE_INFO[currentMode]?.label || 'Unknown Mode'}:</strong> {MODE_INFO[currentMode]?.description || 'No description available'}
         </S.DescriptionText>
       </S.ModeDescription>
     </S.Container>

--- a/src/components/allowed-users/components/NPubManagement/NPubManagement.tsx
+++ b/src/components/allowed-users/components/NPubManagement/NPubManagement.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Button, Input, Table, Space, Modal, Form, Select, message, Popconfirm } from 'antd';
-import { PlusOutlined, UploadOutlined, DeleteOutlined, DownloadOutlined, EditOutlined } from '@ant-design/icons';
-import { useAllowedUsersNpubs, useAllowedUsersValidation } from '@app/hooks/useAllowedUsers';
-import { AllowedUsersSettings, AllowedUsersMode } from '@app/types/allowedUsers.types';
+import { PlusOutlined, DeleteOutlined, EditOutlined } from '@ant-design/icons';
+import { useAllowedUsersList, useAllowedUsersValidation } from '@app/hooks/useAllowedUsers';
+import { AllowedUsersSettings, AllowedUsersMode, AllowedUser } from '@app/types/allowedUsers.types';
 import * as S from './NPubManagement.styles';
 
 interface NPubManagementProps {
@@ -10,19 +10,9 @@ interface NPubManagementProps {
   mode: AllowedUsersMode;
 }
 
-interface AddNpubFormData {
+interface AddUserFormData {
   npub: string;
   tier: string;
-  readAccess: boolean;
-  writeAccess: boolean;
-}
-
-interface UnifiedUser {
-  npub: string;
-  tier: string;
-  readAccess: boolean;
-  writeAccess: boolean;
-  added_at: string;
 }
 
 export const NPubManagement: React.FC<NPubManagementProps> = ({
@@ -31,52 +21,13 @@ export const NPubManagement: React.FC<NPubManagementProps> = ({
 }) => {
   const [isAddModalVisible, setIsAddModalVisible] = useState(false);
   const [isEditModalVisible, setIsEditModalVisible] = useState(false);
-  const [isBulkModalVisible, setIsBulkModalVisible] = useState(false);
-  const [bulkText, setBulkText] = useState('');
-  const [unifiedUsers, setUnifiedUsers] = useState<UnifiedUser[]>([]);
-  const [editingUser, setEditingUser] = useState<UnifiedUser | null>(null);
-  const [addForm] = Form.useForm<AddNpubFormData>();
-  const [editForm] = Form.useForm<AddNpubFormData>();
+  const [editingUser, setEditingUser] = useState<AllowedUser | null>(null);
+  const [addForm] = Form.useForm<AddUserFormData>();
+  const [editForm] = Form.useForm<AddUserFormData>();
 
-  const readNpubs = useAllowedUsersNpubs('read');
-  const writeNpubs = useAllowedUsersNpubs('write');
+  const { users, loading, addUser, removeUser, pagination } = useAllowedUsersList();
   const { validateNpub } = useAllowedUsersValidation();
 
-  // Merge read and write NPUBs into unified list
-  useEffect(() => {
-    const allNpubs = new Map<string, UnifiedUser>();
-
-    // Add read NPUBs
-    readNpubs.npubs.forEach(npub => {
-      allNpubs.set(npub.npub, {
-        npub: npub.npub,
-        tier: npub.tier || settings.tiers[0]?.name || 'basic',
-        readAccess: true,
-        writeAccess: false,
-        added_at: npub.added_at
-      });
-    });
-
-    // Add write NPUBs (merge with existing or create new)
-    writeNpubs.npubs.forEach(npub => {
-      const existing = allNpubs.get(npub.npub);
-      if (existing) {
-        existing.writeAccess = true;
-        // Preserve the tier from read access, or use write tier, or fallback
-        existing.tier = existing.tier || npub.tier || settings.tiers[0]?.name || 'basic';
-      } else {
-        allNpubs.set(npub.npub, {
-          npub: npub.npub,
-          tier: npub.tier || settings.tiers[0]?.name || 'basic',
-          readAccess: false,
-          writeAccess: true,
-          added_at: npub.added_at
-        });
-      }
-    });
-
-    setUnifiedUsers(Array.from(allNpubs.values()));
-  }, [readNpubs.npubs, writeNpubs.npubs, settings.tiers]);
   const tierOptions = settings.tiers.map(tier => {
     const displayFormat = tier.unlimited 
       ? 'unlimited' 
@@ -88,20 +39,10 @@ export const NPubManagement: React.FC<NPubManagementProps> = ({
     };
   });
 
-  const handleAddNpub = async () => {
+  const handleAddUser = async () => {
     try {
       const values = await addForm.validateFields();
-      
-      // Add to read list if read access is enabled
-      if (values.readAccess) {
-        await readNpubs.addNpub(values.npub, values.tier);
-      }
-      
-      // Add to write list if write access is enabled
-      if (values.writeAccess) {
-        await writeNpubs.addNpub(values.npub, values.tier);
-      }
-      
+      await addUser(values.npub, values.tier);
       setIsAddModalVisible(false);
       addForm.resetFields();
     } catch (error) {
@@ -109,42 +50,14 @@ export const NPubManagement: React.FC<NPubManagementProps> = ({
     }
   };
 
-  const handleToggleAccess = async (npub: string, type: 'read' | 'write', enabled: boolean) => {
-    const user = unifiedUsers.find(u => u.npub === npub);
-    if (!user) return;
-
-    // Ensure we have a valid tier - fallback to first available tier if undefined
-    const tierToUse = user.tier || settings.tiers[0]?.name || 'basic';
-
-    try {
-      if (type === 'read') {
-        if (enabled) {
-          await readNpubs.addNpub(npub, tierToUse);
-        } else {
-          await readNpubs.removeNpub(npub);
-        }
-      } else {
-        if (enabled) {
-          await writeNpubs.addNpub(npub, tierToUse);
-        } else {
-          await writeNpubs.removeNpub(npub);
-        }
-      }
-    } catch (error) {
-      message.error(`Failed to update ${type} access`);
-    }
-  };
-
-  const handleEditUser = (user: UnifiedUser) => {
+  const handleEditUser = (user: AllowedUser) => {
     setEditingUser(user);
     setIsEditModalVisible(true);
     // Set form values after modal is visible
     setTimeout(() => {
       editForm.setFieldsValue({
         npub: user.npub,
-        tier: user.tier,
-        readAccess: user.readAccess,
-        writeAccess: user.writeAccess
+        tier: user.tier
       });
     }, 0);
   };
@@ -152,40 +65,11 @@ export const NPubManagement: React.FC<NPubManagementProps> = ({
   const handleSaveEdit = async () => {
     try {
       const values = await editForm.validateFields();
-      const originalUser = editingUser!;
+      if (!editingUser) return;
       
-      // Check what actually changed
-      const readChanged = originalUser.readAccess !== values.readAccess;
-      const writeChanged = originalUser.writeAccess !== values.writeAccess;
-      const tierChanged = originalUser.tier !== values.tier;
-      
-      // Handle read access changes
-      if (readChanged || (tierChanged && values.readAccess)) {
-        if (values.readAccess) {
-          // Remove old entry if exists and re-add with new tier
-          if (originalUser.readAccess) {
-            await readNpubs.removeNpub(values.npub);
-          }
-          await readNpubs.addNpub(values.npub, values.tier);
-        } else {
-          // Remove read access
-          await readNpubs.removeNpub(values.npub);
-        }
-      }
-      
-      // Handle write access changes
-      if (writeChanged || (tierChanged && values.writeAccess)) {
-        if (values.writeAccess) {
-          // Remove old entry if exists and re-add with new tier
-          if (originalUser.writeAccess) {
-            await writeNpubs.removeNpub(values.npub);
-          }
-          await writeNpubs.addNpub(values.npub, values.tier);
-        } else {
-          // Remove write access
-          await writeNpubs.removeNpub(values.npub);
-        }
-      }
+      // Remove the old user and add with new tier
+      await removeUser(editingUser.npub);
+      await addUser(values.npub, values.tier);
       
       setIsEditModalVisible(false);
       setEditingUser(null);
@@ -198,81 +82,10 @@ export const NPubManagement: React.FC<NPubManagementProps> = ({
 
   const handleRemoveUser = async (npub: string) => {
     try {
-      // Remove from both lists
-      await Promise.all([
-        readNpubs.removeNpub(npub).catch(() => { /* Ignore errors if not in list */ }),
-        writeNpubs.removeNpub(npub).catch(() => { /* Ignore errors if not in list */ })
-      ]);
+      await removeUser(npub);
     } catch (error) {
       message.error('Failed to remove user');
     }
-  };
-
-  const handleBulkImport = async () => {
-    if (!bulkText.trim()) {
-      message.error('Please enter NPUBs to import');
-      return;
-    }
-
-    const lines = bulkText.split('\n').filter(line => line.trim());
-    const defaultTier = settings.tiers[0]?.name || 'basic';
-
-    try {
-      for (const line of lines) {
-        const trimmedLine = line.trim();
-        const parts = trimmedLine.split(':');
-        
-        const npub = parts[0];
-        const tier = parts[1] || defaultTier;
-        const permissions = parts[2] || 'r'; // default to read only
-        
-        const hasReadAccess = permissions.includes('r');
-        const hasWriteAccess = permissions.includes('w');
-
-        // Add to read list if read access
-        if (hasReadAccess) {
-          try {
-            await readNpubs.addNpub(npub, tier);
-          } catch (error) {
-            // Might already exist, continue
-          }
-        }
-
-        // Add to write list if write access  
-        if (hasWriteAccess) {
-          try {
-            await writeNpubs.addNpub(npub, tier);
-          } catch (error) {
-            // Might already exist, continue
-          }
-        }
-      }
-      
-      message.success('Bulk import completed');
-      setIsBulkModalVisible(false);
-      setBulkText('');
-    } catch (error) {
-      message.error('Bulk import failed');
-    }
-  };
-
-  const handleExport = () => {
-    const data = unifiedUsers.map(user => {
-      let permissions = '';
-      if (user.readAccess) permissions += 'r';
-      if (user.writeAccess) permissions += 'w';
-      return `${user.npub}:${user.tier}:${permissions}`;
-    }).join('\n');
-    
-    const blob = new Blob([data], { type: 'text/plain' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'allowed-users.txt';
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
   };
 
   const columns = [
@@ -291,41 +104,21 @@ export const NPubManagement: React.FC<NPubManagementProps> = ({
       render: (tier: string) => <S.TierTag>{tier}</S.TierTag>
     },
     {
-      title: 'Read Access',
-      key: 'readAccess',
-      align: 'center' as const,
-      render: (_: any, record: UnifiedUser) => (
-        <S.StyledSwitch
-          checked={record.readAccess}
-          onChange={(checked: boolean) => handleToggleAccess(record.npub, 'read', checked)}
-          loading={readNpubs.loading}
-          size="small"
-        />
-      )
+      title: 'Added By',
+      dataIndex: 'created_by',
+      key: 'created_by',
+      render: (createdBy: string) => createdBy || 'admin'
     },
     {
-      title: 'Write Access',
-      key: 'writeAccess',
-      align: 'center' as const,
-      render: (_: any, record: UnifiedUser) => (
-        <S.StyledSwitch
-          checked={record.writeAccess}
-          onChange={(checked: boolean) => handleToggleAccess(record.npub, 'write', checked)}
-          loading={writeNpubs.loading}
-          size="small"
-        />
-      )
-    },
-    {
-      title: 'Added',
-      dataIndex: 'added_at',
-      key: 'added_at',
+      title: 'Date Added',
+      dataIndex: 'created_at',
+      key: 'created_at',
       render: (date: string) => new Date(date).toLocaleDateString()
     },
     {
       title: 'Actions',
       key: 'actions',
-      render: (_: any, record: UnifiedUser) => (
+      render: (_: any, record: AllowedUser) => (
         <Space size="small">
           <Button
             type="text"
@@ -335,7 +128,7 @@ export const NPubManagement: React.FC<NPubManagementProps> = ({
             title="Edit user"
           />
           <Popconfirm
-            title="Are you sure you want to remove this user completely?"
+            title="Are you sure you want to remove this user?"
             onConfirm={() => handleRemoveUser(record.npub)}
           >
             <Button
@@ -362,28 +155,17 @@ export const NPubManagement: React.FC<NPubManagementProps> = ({
           >
             Add User
           </Button>
-          <Button
-            icon={<UploadOutlined />}
-            onClick={() => setIsBulkModalVisible(true)}
-          >
-            Bulk Import
-          </Button>
-          <Button
-            icon={<DownloadOutlined />}
-            onClick={handleExport}
-            disabled={unifiedUsers.length === 0}
-          >
-            Export
-          </Button>
         </Space>
       </S.TabHeader>
       
       <Table
         columns={columns}
-        dataSource={unifiedUsers}
-        loading={readNpubs.loading || writeNpubs.loading}
+        dataSource={users}
+        loading={loading}
         pagination={{
-          pageSize: 20,
+          current: pagination.page,
+          pageSize: pagination.page_size,
+          total: pagination.total_items,
           showSizeChanger: false,
           showTotal: (total) => `Total ${total} users`
         }}
@@ -394,14 +176,14 @@ export const NPubManagement: React.FC<NPubManagementProps> = ({
       <Modal
         title="Add User"
         open={isAddModalVisible}
-        onOk={handleAddNpub}
+        onOk={handleAddUser}
         onCancel={() => {
           setIsAddModalVisible(false);
           addForm.resetFields();
         }}
         destroyOnClose
       >
-        <Form form={addForm} layout="vertical" initialValues={{ readAccess: true, writeAccess: false }}>
+        <Form form={addForm} layout="vertical">
           <Form.Item
             name="npub"
             label="NPUB"
@@ -423,26 +205,6 @@ export const NPubManagement: React.FC<NPubManagementProps> = ({
           >
             <Select placeholder="Select tier" options={tierOptions} />
           </Form.Item>
-
-          <Form.Item
-            label="Permissions"
-            style={{ marginBottom: 0 }}
-          >
-            <Space direction="vertical">
-              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--text-main-color)' }}>
-                <Form.Item name="readAccess" valuePropName="checked" style={{ marginBottom: 0 }}>
-                  <S.StyledSwitch size="small" />
-                </Form.Item>
-                <span>Read Access</span>
-              </div>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--text-main-color)' }}>
-                <Form.Item name="writeAccess" valuePropName="checked" style={{ marginBottom: 0 }}>
-                  <S.StyledSwitch size="small" />
-                </Form.Item>
-                <span>Write Access</span>
-              </div>
-            </Space>
-          </Form.Item>
         </Form>
       </Modal>
 
@@ -461,12 +223,6 @@ export const NPubManagement: React.FC<NPubManagementProps> = ({
         <Form 
           form={editForm} 
           layout="vertical"
-          initialValues={{ 
-            npub: editingUser?.npub || '',
-            tier: editingUser?.tier || '',
-            readAccess: editingUser?.readAccess || false,
-            writeAccess: editingUser?.writeAccess || false
-          }}
         >
           <Form.Item
             name="npub"
@@ -482,55 +238,7 @@ export const NPubManagement: React.FC<NPubManagementProps> = ({
           >
             <Select placeholder="Select tier" options={tierOptions} />
           </Form.Item>
-
-          <Form.Item
-            label="Permissions"
-            style={{ marginBottom: 0 }}
-          >
-            <Space direction="vertical">
-              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--text-main-color)' }}>
-                <Form.Item name="readAccess" valuePropName="checked" style={{ marginBottom: 0 }}>
-                  <S.StyledSwitch size="small" />
-                </Form.Item>
-                <span>Read Access</span>
-              </div>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--text-main-color)' }}>
-                <Form.Item name="writeAccess" valuePropName="checked" style={{ marginBottom: 0 }}>
-                  <S.StyledSwitch size="small" />
-                </Form.Item>
-                <span>Write Access</span>
-              </div>
-            </Space>
-          </Form.Item>
         </Form>
-      </Modal>
-
-      {/* Bulk Import Modal */}
-      <Modal
-        title="Bulk Import Users"
-        open={isBulkModalVisible}
-        onOk={handleBulkImport}
-        onCancel={() => {
-          setIsBulkModalVisible(false);
-          setBulkText('');
-        }}
-        width={600}
-      >
-        <S.BulkImportContainer>
-          <p>Enter NPUBs, one per line. Format options:</p>
-          <ul>
-            <li><code>npub1...</code> (will use default tier and read access only)</li>
-            <li><code>npub1...:tier_name</code> (specify tier, read access only)</li>
-            <li><code>npub1...:tier_name:rw</code> (specify tier with read+write access)</li>
-          </ul>
-          
-          <Input.TextArea
-            value={bulkText}
-            onChange={(e) => setBulkText(e.target.value)}
-            placeholder="npub1abc123...&#10;npub1def456...:premium&#10;npub1ghi789...:basic:rw"
-            rows={10}
-          />
-        </S.BulkImportContainer>
       </Modal>
     </S.Container>
   );

--- a/src/components/allowed-users/components/PermissionsConfig/PermissionsConfig.styles.ts
+++ b/src/components/allowed-users/components/PermissionsConfig/PermissionsConfig.styles.ts
@@ -61,3 +61,38 @@ export const NoteItem = styled.div`
     color: var(--text-main-color);
   }
 `;
+
+export const PermissionExplanations = styled.div`
+  margin-top: 1rem;
+  padding: 1rem;
+  background: var(--background-color-light);
+  border-radius: 6px;
+  border-left: 4px solid var(--primary-color);
+
+  h4 {
+    margin: 0 0 0.75rem 0;
+    color: var(--text-main-color);
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 1.25rem;
+    
+    li {
+      margin-bottom: 0.5rem;
+      font-size: 13px;
+      color: var(--text-secondary-color);
+      line-height: 1.4;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+
+      strong {
+        color: var(--text-main-color);
+      }
+    }
+  }
+`;

--- a/src/components/allowed-users/components/RelayOwnerConfig/RelayOwnerConfig.styles.ts
+++ b/src/components/allowed-users/components/RelayOwnerConfig/RelayOwnerConfig.styles.ts
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+import { media } from '../../../../styles/themes/constants';
+
+export const Container = styled.div`
+  width: 100%;
+`;
+
+export const NpubSection = styled.div`
+  margin-top: 1rem;
+`;
+
+export const SectionTitle = styled.h3`
+  margin: 0 0 0.5rem 0;
+  color: var(--text-main-color);
+  font-size: 16px;
+  font-weight: 600;
+`;
+
+export const SectionDescription = styled.p`
+  margin: 0 0 1rem 0;
+  color: var(--text-secondary-color);
+  font-size: 14px;
+  line-height: 1.4;
+`;
+
+export const InputContainer = styled.div`
+  margin-bottom: 0.75rem;
+`;
+
+export const AutoDetectedIndicator = styled.div`
+  display: flex;
+  align-items: center;
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(82, 196, 26, 0.1);
+  border-radius: 4px;
+  border: 1px solid rgba(82, 196, 26, 0.3);
+`;
+
+export const ErrorText = styled.div`
+  color: #ff4d4f;
+  font-size: 13px;
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(255, 77, 79, 0.1);
+  border-radius: 4px;
+  border: 1px solid rgba(255, 77, 79, 0.3);
+`;

--- a/src/components/allowed-users/components/RelayOwnerConfig/RelayOwnerConfig.tsx
+++ b/src/components/allowed-users/components/RelayOwnerConfig/RelayOwnerConfig.tsx
@@ -1,0 +1,205 @@
+import React, { useState, useEffect } from 'react';
+import { Input, Alert, Button, Space, Typography, message } from 'antd';
+import { CheckOutlined, UserOutlined, SaveOutlined } from '@ant-design/icons';
+import { AllowedUsersSettings, RelayOwner } from '@app/types/allowedUsers.types';
+import { getRelayOwner, setRelayOwner, removeRelayOwner } from '@app/api/allowedUsers.api';
+import { nip19 } from 'nostr-tools';
+import * as S from './RelayOwnerConfig.styles';
+
+const { Text } = Typography;
+
+interface RelayOwnerConfigProps {
+  settings: AllowedUsersSettings;
+  onSettingsChange: (settings: AllowedUsersSettings) => void;
+  disabled?: boolean;
+}
+
+export const RelayOwnerConfig: React.FC<RelayOwnerConfigProps> = ({
+  settings,
+  onSettingsChange,
+  disabled = false
+}) => {
+  const [npubValue, setNpubValue] = useState('');
+  const [currentOwner, setCurrentOwner] = useState<RelayOwner | null>(null);
+  const [isAutoDetected, setIsAutoDetected] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    loadCurrentOwner();
+  }, []);
+
+  const loadCurrentOwner = async () => {
+    try {
+      setLoading(true);
+      const response = await getRelayOwner();
+      
+      if (response.relay_owner) {
+        setCurrentOwner(response.relay_owner);
+        try {
+          const npubEncoded = nip19.npubEncode(response.relay_owner.npub);
+          setNpubValue(npubEncoded);
+        } catch (error) {
+          console.error('Failed to encode npub:', error);
+          setNpubValue(response.relay_owner.npub);
+        }
+        setIsAutoDetected(false);
+      } else {
+        setCurrentOwner(null);
+        setNpubValue('');
+        setIsAutoDetected(false);
+      }
+    } catch (error) {
+      console.error('Failed to load current owner:', error);
+      message.error('Failed to load relay owner');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSaveOwner = async () => {
+    if (!validateNpub(npubValue)) {
+      message.error('Please enter a valid NPUB');
+      return;
+    }
+
+    try {
+      setSaving(true);
+      
+      let hexValue = npubValue;
+      try {
+        if (npubValue.startsWith('npub1')) {
+          const decoded = nip19.decode(npubValue);
+          hexValue = decoded.data as string;
+        }
+      } catch (error) {
+        console.error('Failed to decode npub:', error);
+        message.error('Invalid NPUB format');
+        return;
+      }
+      
+      await setRelayOwner({ npub: hexValue });
+      await loadCurrentOwner();
+      setIsAutoDetected(false);
+      message.success('Relay owner set successfully');
+      
+    } catch (error) {
+      console.error('❌ [RelayOwnerConfig] Failed to save owner:', error);
+      message.error('Failed to save relay owner');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRemoveOwner = async () => {
+    if (!currentOwner) return;
+
+    try {
+      setSaving(true);
+      await removeRelayOwner();
+      setCurrentOwner(null);
+      setNpubValue('');
+      message.success('Relay owner cleared successfully');
+    } catch (error) {
+      console.error('Failed to remove owner:', error);
+      message.error('Failed to remove relay owner');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const validateNpub = (value: string): boolean => {
+    if (!value) return false;
+    return value.startsWith('npub1') && value.length === 63;
+  };
+
+  const isValid = validateNpub(npubValue);
+  // Compare with the current encoded npub value
+  const currentNpubEncoded = currentOwner ? 
+    (() => {
+      try {
+        return nip19.npubEncode(currentOwner.npub);
+      } catch {
+        return currentOwner.npub;
+      }
+    })() : '';
+  const hasChanges = npubValue !== currentNpubEncoded;
+
+  return (
+    <S.Container>
+      <Alert
+        message="Only-Me Mode Configuration"
+        description="In only-me mode, only the relay owner can write to this relay. Set your NPUB below to identify yourself as the owner."
+        type="info"
+        showIcon
+        style={{ marginBottom: '1.5rem' }}
+      />
+
+      <S.NpubSection>
+        <S.SectionTitle>
+          <UserOutlined /> Relay Owner
+        </S.SectionTitle>
+        
+        <div>
+          <S.SectionDescription>
+            {currentOwner ? 'Current relay owner:' : 'Set your NPUB to identify yourself as the relay operator:'}
+          </S.SectionDescription>
+          
+          <S.InputContainer>
+            <Input
+              value={npubValue}
+              onChange={(e) => setNpubValue(e.target.value)}
+              placeholder="Enter your NPUB (e.g., npub1abc...def123)"
+              disabled={disabled || loading}
+              status={npubValue && !isValid ? 'error' : undefined}
+              style={{
+                fontFamily: 'monospace',
+                fontSize: '14px',
+                backgroundColor: 'var(--background-color-secondary)',
+                border: '1px solid var(--border-color-base)',
+                color: 'var(--text-main-color)'
+              }}
+            />
+          </S.InputContainer>
+          
+          <Space style={{ marginTop: '1rem' }}>
+            <Button
+              type="primary"
+              icon={<SaveOutlined />}
+              onClick={handleSaveOwner}
+              loading={saving}
+              disabled={disabled || !hasChanges || !isValid}
+            >
+              {currentOwner ? 'Update Owner' : 'Set as Owner'}
+            </Button>
+            {currentOwner && (
+              <Button
+                danger
+                onClick={handleRemoveOwner}
+                loading={saving}
+                disabled={disabled}
+              >
+                Remove Owner
+              </Button>
+            )}
+          </Space>
+        </div>
+
+        {isAutoDetected && (
+          <S.AutoDetectedIndicator>
+            <CheckOutlined style={{ color: '#52c41a', marginRight: '8px' }} />
+            <Text style={{ color: '#52c41a', fontSize: '13px' }}>
+              Auto-detected from Nestr
+            </Text>
+          </S.AutoDetectedIndicator>
+        )}
+
+        {npubValue && !isValid && (
+          <S.ErrorText>
+            Invalid NPUB format. Must start with "npub1" and be 63 characters long.
+          </S.ErrorText>
+        )}
+      </S.NpubSection>
+    </S.Container>
+  );
+};

--- a/src/components/allowed-users/components/TierEditor/TierEditor.tsx
+++ b/src/components/allowed-users/components/TierEditor/TierEditor.tsx
@@ -51,12 +51,11 @@ export const TierEditor: React.FC<TierEditorProps> = ({
         price_sats: priceSats,
         monthly_limit_bytes: displayFormat.unlimited ? 0 : 
           Math.round(displayFormat.value * getUnitMultiplier(displayFormat.unit)),
-        unlimited: displayFormat.unlimited,
-        active: tier.active // Preserve active state
+        unlimited: displayFormat.unlimited
       };
       onTierChange(updatedTier);
     }
-  }, [displayFormat, name, priceSats, isValid, onTierChange, tier.active]);
+  }, [displayFormat, name, priceSats, isValid, onTierChange]);
 
   const getUnitMultiplier = (unit: DataUnit): number => {
     switch (unit) {

--- a/src/components/allowed-users/components/TiersConfig/TiersConfig.tsx
+++ b/src/components/allowed-users/components/TiersConfig/TiersConfig.tsx
@@ -25,8 +25,10 @@ export const TiersConfig: React.FC<TiersConfigProps> = ({
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [currentTier, setCurrentTier] = useState<AllowedUsersTier | null>(null);
 
-  const isPaidMode = mode === 'paid';
-  const isFreeMode = mode === 'free';
+  const isPaidMode = mode === 'subscription';
+  const isPublicMode = mode === 'public';
+  const isInviteMode = mode === 'invite-only';
+  const isOnlyMeMode = mode === 'only-me';
 
   const handleFreeTierChange = (tierName: string) => {
     const updatedTiers = settings.tiers.map(tier => ({
@@ -42,11 +44,27 @@ export const TiersConfig: React.FC<TiersConfigProps> = ({
     onSettingsChange(updatedSettings);
   };
 
+  const handleSelectActiveTier = (tierIndex: number) => {
+    // For public mode, mark the selected tier as active and others as inactive
+    if (isPublicMode) {
+      const updatedTiers = settings.tiers.map((tier, index) => ({
+        ...tier,
+        active: index === tierIndex
+      }));
+      
+      const updatedSettings = {
+        ...settings,
+        tiers: updatedTiers
+      };
+      onSettingsChange(updatedSettings);
+    }
+  };
+
   const handleAddTier = () => {
     setEditingIndex(null);
     setCurrentTier({
       name: '',
-      price_sats: isFreeMode ? 0 : 1000,
+      price_sats: isPublicMode ? 0 : 1000,
       monthly_limit_bytes: 1073741824, // 1 GB default
       unlimited: false
     });
@@ -80,10 +98,10 @@ export const TiersConfig: React.FC<TiersConfigProps> = ({
       return; // TierEditor should show validation error
     }
 
-    // Force price to 0 for free mode
+    // Force price to 0 for public mode and only-me mode (free tiers)
     const finalTier = {
       ...currentTier,
-      price_sats: isFreeMode ? 0 : currentTier.price_sats
+      price_sats: (isPublicMode || isOnlyMeMode) ? 0 : currentTier.price_sats
     };
 
     let newTiers: AllowedUsersTier[];
@@ -171,8 +189,8 @@ export const TiersConfig: React.FC<TiersConfigProps> = ({
     <S.Container>
       {isPaidMode && (
         <Alert
-          message="Paid Mode Active"
-          description="All tiers must have a price greater than 0. Free tiers are not allowed in paid mode."
+          message="Subscription Mode Active"
+          description="All tiers must have a price greater than 0. Free tiers are not allowed in subscription mode."
           type="warning"
           showIcon
           style={{ 
@@ -184,10 +202,10 @@ export const TiersConfig: React.FC<TiersConfigProps> = ({
         />
       )}
       
-      {isFreeMode && (
+      {isPublicMode && (
         <Alert
-          message="Free Mode Active"
-          description="All tiers are automatically set to free (price = 0) regardless of input."
+          message="Public Mode Active"
+          description="Configure free tier storage limits. All tiers will be free (price = 0) in public mode."
           type="success"
           showIcon
           style={{ 
@@ -199,10 +217,25 @@ export const TiersConfig: React.FC<TiersConfigProps> = ({
         />
       )}
       
-      {mode === 'exclusive' && (
+      {isInviteMode && (
         <Alert
-          message="Exclusive Mode Active"
+          message="Invite-Only Mode Active"
           description="Tiers can have any price. Users must be manually added to access lists."
+          type="info"
+          showIcon
+          style={{ 
+            marginBottom: '1rem',
+            backgroundColor: '#25284B',
+            border: '1px solid #d9d9d9',
+            color: '#d9d9d9'
+          }}
+        />
+      )}
+      
+      {isOnlyMeMode && (
+        <Alert
+          message="Only Me Mode Active"
+          description="Personal relay configuration. Only your npub can write to this relay."
           type="info"
           showIcon
           style={{ 
@@ -216,9 +249,11 @@ export const TiersConfig: React.FC<TiersConfigProps> = ({
 
       <S.TiersHeader>
         <S.TiersTitle>
-          {isFreeMode ? 'Free Tier Selection' : 'Subscription Tiers'}
+          {isPublicMode ? 'Free Tier Configuration' : 
+           isOnlyMeMode ? 'Personal Tier' : 
+           'Subscription Tiers'}
         </S.TiersTitle>
-        {!isFreeMode && (
+        {!isOnlyMeMode && (
           <Button
             type="primary"
             icon={<PlusOutlined />}
@@ -230,40 +265,74 @@ export const TiersConfig: React.FC<TiersConfigProps> = ({
         )}
       </S.TiersHeader>
 
-      {isFreeMode ? (
-        <Radio.Group
-          value={settings.tiers.find(tier => tier.active)?.name}
-          onChange={(e) => handleFreeTierChange(e.target.value)}
-          disabled={disabled}
-        >
-          <Space direction="vertical" style={{ width: '100%' }}>
-            {settings.tiers.map((tier, index) => {
-              const display = tier.unlimited 
-                ? { value: 0, unit: 'MB' as const, unlimited: true }
-                : { ...bytesToDisplayFormat(tier.monthly_limit_bytes), unlimited: false };
-              
-              return (
-                <Card
-                  key={index}
-                  size="small"
-                  style={{ 
-                    cursor: disabled ? 'not-allowed' : 'pointer',
-                    border: tier.active ? '2px solid var(--primary-color)' : '1px solid #d9d9d9'
-                  }}
-                  onClick={() => !disabled && handleFreeTierChange(tier.name)}
-                >
-                  <Radio value={tier.name} disabled={disabled}>
-                    <Space>
-                      <S.DataLimit>{tier.name}</S.DataLimit>
-                      <S.DataLimit>{displayToFriendlyString(display)}</S.DataLimit>
-                      <S.Price $isFree={true}>Free</S.Price>
-                    </Space>
-                  </Radio>
-                </Card>
-              );
-            })}
-          </Space>
-        </Radio.Group>
+      {isPublicMode ? (
+        <div>
+          <Alert
+            message="Select Free Tier for Public Users"
+            description="Choose one tier that will be applied to all free users on your public relay."
+            type="info"
+            showIcon
+            style={{ marginBottom: '1rem' }}
+          />
+          
+          <Radio.Group
+            value={settings.tiers.findIndex(tier => tier.active === true) !== -1 
+              ? settings.tiers.findIndex(tier => tier.active === true) 
+              : 0}
+            onChange={(e) => handleSelectActiveTier(e.target.value)}
+            disabled={disabled}
+            style={{ width: '100%' }}
+          >
+            <Space direction="vertical" style={{ width: '100%' }}>
+              {settings.tiers.map((tier, index) => (
+                <Radio key={index} value={index} style={{ width: '100%' }}>
+                  <Card
+                    size="small"
+                    style={{
+                      marginLeft: '24px',
+                      width: 'calc(100% - 24px)',
+                      backgroundColor: tier.active ? '#f6ffed' : 'transparent',
+                      border: tier.active ? '1px solid #b7eb8f' : '1px solid var(--border-color-base)'
+                    }}
+                  >
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                      <div>
+                        <strong>{tier.name}</strong>
+                        <div style={{ color: 'var(--text-secondary-color)', fontSize: '13px' }}>
+                          Data Limit: {tier.unlimited ? 'Unlimited' : displayToFriendlyString(bytesToDisplayFormat(tier.monthly_limit_bytes))}
+                        </div>
+                      </div>
+                      <div style={{ display: 'flex', gap: '8px' }}>
+                        <Button
+                          type="text"
+                          icon={<EditOutlined />}
+                          onClick={() => handleEditTier(index)}
+                          disabled={disabled}
+                          size="small"
+                        />
+                        {settings.tiers.length > 1 && (
+                          <Popconfirm
+                            title="Are you sure you want to delete this tier?"
+                            onConfirm={() => handleDeleteTier(index)}
+                            disabled={disabled}
+                          >
+                            <Button
+                              type="text"
+                              danger
+                              icon={<DeleteOutlined />}
+                              disabled={disabled}
+                              size="small"
+                            />
+                          </Popconfirm>
+                        )}
+                      </div>
+                    </div>
+                  </Card>
+                </Radio>
+              ))}
+            </Space>
+          </Radio.Group>
+        </div>
       ) : (
         <Table
           columns={columns}
@@ -294,7 +363,7 @@ export const TiersConfig: React.FC<TiersConfigProps> = ({
 
         {isPaidMode && (
           <Alert
-            message="Note: Free tiers (price = 0) are not allowed in paid mode"
+            message="Note: Free tiers (price = 0) are not allowed in subscription mode"
             type="warning"
             showIcon
             style={{
@@ -306,9 +375,23 @@ export const TiersConfig: React.FC<TiersConfigProps> = ({
           />
         )}
         
-        {isFreeMode && (
+        {isPublicMode && (
           <Alert
-            message="Note: Price will be automatically set to 0 (free) in free mode"
+            message="Note: Price will be automatically set to 0 (free) in public mode"
+            type="success"
+            showIcon
+            style={{
+              marginTop: 16,
+              backgroundColor: '#fafafa',
+              border: '1px solid #d9d9d9',
+              color: '#262626'
+            }}
+          />
+        )}
+        
+        {isOnlyMeMode && (
+          <Alert
+            message="Note: Personal tier is always free and unlimited for relay owner"
             type="success"
             showIcon
             style={{

--- a/src/components/allowed-users/layouts/AllowedUsersLayout.tsx
+++ b/src/components/allowed-users/layouts/AllowedUsersLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Card, Row, Col, Spin, Alert, Button, Space } from 'antd';
 import { SaveOutlined } from '@ant-design/icons';
 import { useAllowedUsersSettings } from '@app/hooks/useAllowedUsers';
@@ -6,17 +6,18 @@ import { ModeSelector } from '../components/ModeSelector/ModeSelector';
 import { PermissionsConfig } from '../components/PermissionsConfig/PermissionsConfig';
 import { TiersConfig } from '../components/TiersConfig/TiersConfig';
 import { NPubManagement } from '../components/NPubManagement/NPubManagement';
+import { RelayOwnerConfig } from '../components/RelayOwnerConfig/RelayOwnerConfig';
 import { AllowedUsersMode, MODE_CONFIGURATIONS, AllowedUsersSettings, DEFAULT_TIERS } from '@app/types/allowedUsers.types';
 import * as S from './AllowedUsersLayout.styles';
 
 export const AllowedUsersLayout: React.FC = () => {
   const { settings, loading, error, updateSettings } = useAllowedUsersSettings();
-  const [currentMode, setCurrentMode] = useState<AllowedUsersMode>('free');
+  const [currentMode, setCurrentMode] = useState<AllowedUsersMode>('public');
   const [localSettings, setLocalSettings] = useState<AllowedUsersSettings | null>(null);
   const [hasChanges, setHasChanges] = useState(false);
   const [saving, setSaving] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (settings) {
       setCurrentMode(settings.mode);
       setLocalSettings(settings);
@@ -29,69 +30,35 @@ export const AllowedUsersLayout: React.FC = () => {
 
     const modeConfig = MODE_CONFIGURATIONS[mode];
     
-    // Use mode-specific default tiers or existing tiers if they're compatible
-    let tiers = localSettings.tiers;
+    // Comprehensive logging for mode changes
+    console.group('🔄 [UI] Mode Change Handler');
+    console.log('🎯 Selected mode:', mode);
+    console.log('⚙️ Mode configuration:', modeConfig);
+    console.log('📋 Current local settings:', localSettings);
+    console.log('🔒 Forced read permission:', modeConfig.forcedRead);
+    console.log('🔒 Forced write permission:', modeConfig.forcedWrite);
+    console.log('📖 Available read options:', modeConfig.readOptions);
+    console.log('✍️ Available write options:', modeConfig.writeOptions);
+    console.log('🏷️ Default tiers for mode:', DEFAULT_TIERS[mode]);
+    console.groupEnd();
     
-    // Check if current tiers are compatible with the new mode
-    const isCompatibleTiers = (currentTiers: typeof tiers, targetMode: AllowedUsersMode): boolean => {
-      if (currentTiers.length === 0) return false;
-      
-      return currentTiers.every(tier => {
-        const hasValidName = tier.name && tier.name.trim() !== '';
-        
-        if (targetMode === 'paid') {
-          // Paid mode requires at least one tier with non-zero price
-          return hasValidName && tier.price_sats > 0;
-        } else if (targetMode === 'free') {
-          // Free mode should have price 0
-          return hasValidName && tier.price_sats === 0;
-        } else if (targetMode === 'exclusive') {
-          // Exclusive mode can have any price
-          return hasValidName;
-        }
-        
-        return hasValidName;
-      });
-    };
-    
-    // Each mode should use its own defaults when switching modes
-    // Only preserve existing tiers if we're already in the target mode (backend data)
-    const currentMode = localSettings.mode;
-    
-    if (currentMode === mode) {
-      // We're already in this mode (from backend), keep existing tiers if compatible
-      if (isCompatibleTiers(localSettings.tiers, mode)) {
-        tiers = localSettings.tiers;
-        if (mode === 'free') {
-          // Ensure all prices are "0" for free mode
-          tiers = tiers.map(tier => ({
-            ...tier,
-            price: '0'
-          }));
-        }
-      } else {
-        // Backend data isn't compatible with mode, use defaults
-        tiers = DEFAULT_TIERS[mode];
-      }
-    } else {
-      // Switching between different modes, always use mode-specific defaults
-      tiers = DEFAULT_TIERS[mode];
-    }
-    
-    const updatedSettings = {
+    // Apply mode-specific forced permissions and defaults
+    const updatedSettings: AllowedUsersSettings = {
       ...localSettings,
       mode,
-      tiers,
-      // Adjust scopes based on mode constraints
-      read_access: {
-        ...localSettings.read_access,
-        scope: modeConfig.readOptions[0].value // Default to first available option
-      },
-      write_access: {
-        ...localSettings.write_access,
-        scope: modeConfig.writeOptions[0].value // Default to first available option
-      }
+      read: modeConfig.forcedRead || modeConfig.readOptions[0],
+      write: modeConfig.forcedWrite || modeConfig.writeOptions[0],
+      tiers: DEFAULT_TIERS[mode]
+      // Note: relay_owner_npub is no longer managed in settings - it's handled via /api/allowed-users
     };
+
+    console.group('📝 [UI] Updated Settings After Mode Change');
+    console.log('🆕 New settings object:', updatedSettings);
+    console.log('🎯 Final mode:', updatedSettings.mode);
+    console.log('📖 Final read permission:', updatedSettings.read);
+    console.log('✍️ Final write permission:', updatedSettings.write);
+    console.log('🏷️ Final tiers:', updatedSettings.tiers);
+    console.groupEnd();
 
     setLocalSettings(updatedSettings);
     setCurrentMode(mode);
@@ -148,10 +115,10 @@ export const AllowedUsersLayout: React.FC = () => {
     return null;
   }
 
-  const modeConfig = MODE_CONFIGURATIONS[currentMode];
-  const showNpubManagement = modeConfig.requiresNpubManagement ||
-    (localSettings.read_access.scope === 'allowed_users' || localSettings.write_access.scope === 'allowed_users');
-  const showTiers = currentMode === 'paid' || currentMode === 'free' || currentMode === 'exclusive';
+  // Determine what sections to show based on mode and permissions
+  const showNpubManagement = localSettings.read === 'allowed_users' || localSettings.write === 'allowed_users';
+  const showTiers = currentMode === 'subscription' || currentMode === 'invite-only' || currentMode === 'public' || currentMode === 'only-me';
+  const showRelayOwnerConfig = currentMode === 'only-me';
 
   return (
     <S.Container>
@@ -172,19 +139,34 @@ export const AllowedUsersLayout: React.FC = () => {
         </Col>
 
         <Col span={24}>
-          <Card title="Permissions Configuration" loading={loading}>
+          <Card title="Global Permissions" loading={loading}>
             <PermissionsConfig
               settings={localSettings}
-              mode={currentMode}
               onSettingsChange={handleSettingsUpdate}
               disabled={loading || saving}
             />
           </Card>
         </Col>
 
+        {showRelayOwnerConfig && (
+          <Col span={24}>
+            <Card title="Relay Owner Configuration" loading={loading}>
+              <RelayOwnerConfig
+                settings={localSettings}
+                onSettingsChange={handleSettingsUpdate}
+                disabled={loading || saving}
+              />
+            </Card>
+          </Col>
+        )}
+
         {showTiers && (
           <Col span={24}>
-            <Card title="Tiers Configuration" loading={loading}>
+            <Card title={
+              currentMode === 'public' ? 'Free Tier Configuration' : 
+              currentMode === 'only-me' ? 'Only Me Tiers' : 
+              'Subscription Tiers'
+            } loading={loading}>
               <TiersConfig
                 settings={localSettings}
                 mode={currentMode}
@@ -197,7 +179,7 @@ export const AllowedUsersLayout: React.FC = () => {
 
         {showNpubManagement && (
           <Col span={24}>
-            <Card title="User Lists Management">
+            <Card title="Allowed Users Management">
               <NPubManagement
                 settings={localSettings}
                 mode={currentMode}

--- a/src/components/relay-dashboard/paid-subscribers/PaidSubscribers.tsx
+++ b/src/components/relay-dashboard/paid-subscribers/PaidSubscribers.tsx
@@ -47,7 +47,7 @@ export const PaidSubscribers: React.FC = () => {
     setAllSubscribers([...subscribers]); // Start with current subscribers
     
     // Fetch more subscribers if available
-    let currentSubscribers = [...subscribers];
+    const currentSubscribers = [...subscribers];
     let canFetchMore = hasMore;
     
     while (canFetchMore) {

--- a/src/hooks/useAllowedUsers.ts
+++ b/src/hooks/useAllowedUsers.ts
@@ -3,23 +3,26 @@ import { message } from 'antd';
 import {
   getAllowedUsersSettings,
   updateAllowedUsersSettings,
-  getReadNpubs,
-  getWriteNpubs,
-  addReadNpub,
-  addWriteNpub,
-  removeReadNpub,
-  removeWriteNpub,
-  bulkImportNpubs
+  getAllowedUsers,
+  addAllowedUser,
+  removeAllowedUser
 } from '@app/api/allowedUsers.api';
 import {
   AllowedUsersSettings,
-  AllowedUsersNpub,
   AllowedUsersMode,
-  BulkImportRequest
+  AllowedUser,
+  AllowedUsersResponse,
+  DEFAULT_TIERS
 } from '@app/types/allowedUsers.types';
 
+// Hook for managing allowed users settings
 export const useAllowedUsersSettings = () => {
-  const [settings, setSettings] = useState<AllowedUsersSettings | null>(null);
+  const [settings, setSettings] = useState<AllowedUsersSettings>({
+    mode: 'public',
+    read: 'all_users',
+    write: 'all_users',
+    tiers: DEFAULT_TIERS['public']
+  });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -32,27 +35,7 @@ export const useAllowedUsersSettings = () => {
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to fetch settings';
       setError(errorMessage);
-      
-      // Don't show error message if it's just that the endpoint doesn't exist yet
-      if (!errorMessage.includes('404') && !errorMessage.includes('not valid JSON')) {
-        message.error(errorMessage);
-      }
-      
-      // Set default settings if API is not available yet
-      setSettings({
-        mode: 'free',
-        read_access: {
-          enabled: true,
-          scope: 'all_users'
-        },
-        write_access: {
-          enabled: true,
-          scope: 'all_users'
-        },
-        tiers: [
-          { name: 'Basic', price_sats: 0, monthly_limit_bytes: 1073741824, unlimited: false }
-        ]
-      });
+      message.error(errorMessage);
     } finally {
       setLoading(false);
     }
@@ -62,21 +45,14 @@ export const useAllowedUsersSettings = () => {
     setLoading(true);
     setError(null);
     try {
-      const result = await updateAllowedUsersSettings(newSettings);
-      if (result.success) {
-        setSettings(newSettings);
-        message.success('Settings updated successfully');
-      } else {
-        throw new Error(result.message);
-      }
+      await updateAllowedUsersSettings(newSettings);
+      setSettings(newSettings);
+      message.success('Settings updated successfully');
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to update settings';
       setError(errorMessage);
-      if (errorMessage.includes('access control not initialized')) {
-        message.error('Please restart the relay after configuration changes');
-      } else {
-        message.error(errorMessage);
-      }
+      message.error(errorMessage);
+      throw err;
     } finally {
       setLoading(false);
     }
@@ -95,167 +71,104 @@ export const useAllowedUsersSettings = () => {
   };
 };
 
-export const useAllowedUsersNpubs = (type: 'read' | 'write') => {
-  const [npubs, setNpubs] = useState<AllowedUsersNpub[]>([]);
-  const [total, setTotal] = useState(0);
+// Hook for managing allowed users list
+export const useAllowedUsersList = () => {
+  const [users, setUsers] = useState<AllowedUser[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [page, setPage] = useState(1);
-  const [pageSize] = useState(20);
+  const [pagination, setPagination] = useState({
+    page: 1,
+    page_size: 20,
+    total_pages: 1,
+    total_items: 0
+  });
 
-  const fetchNpubs = useCallback(async (pageNum: number = page) => {
+  const fetchUsers = useCallback(async (page = 1, pageSize = 20) => {
     setLoading(true);
     setError(null);
     try {
-      const data = type === 'read'
-        ? await getReadNpubs(pageNum, pageSize)
-        : await getWriteNpubs(pageNum, pageSize);
-      
-      setNpubs(data.npubs);
-      setTotal(data.total);
-      setPage(data.page);
+      const response: AllowedUsersResponse = await getAllowedUsers(page, pageSize);
+      setUsers(response.allowed_users);
+      setPagination(response.pagination);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : `Failed to fetch ${type} NPUBs`;
+      const errorMessage = err instanceof Error ? err.message : 'Failed to fetch users';
       setError(errorMessage);
-      
-      // Don't show error message if it's just that the endpoint doesn't exist yet
-      if (!errorMessage.includes('404') && !errorMessage.includes('not valid JSON')) {
-        message.error(errorMessage);
-      }
-      
-      // Set empty data if API is not available yet
-      setNpubs([]);
-      setTotal(0);
-      setPage(1);
-    } finally {
-      setLoading(false);
-    }
-  }, [type, page, pageSize]);
-
-  const addNpub = useCallback(async (npub: string, tier: string) => {
-    setLoading(true);
-    try {
-      const result = type === 'read' 
-        ? await addReadNpub(npub, tier)
-        : await addWriteNpub(npub, tier);
-      
-      if (result.success) {
-        message.success(`NPUB added to ${type} list successfully`);
-        await fetchNpubs(1); // Refresh the list
-      } else {
-        throw new Error(result.message);
-      }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : `Failed to add NPUB to ${type} list`;
       message.error(errorMessage);
     } finally {
       setLoading(false);
     }
-  }, [type, fetchNpubs]);
+  }, []);
 
-  const removeNpub = useCallback(async (npub: string) => {
+  const addUser = useCallback(async (npub: string, tier: string) => {
     setLoading(true);
+    setError(null);
     try {
-      const result = type === 'read' 
-        ? await removeReadNpub(npub)
-        : await removeWriteNpub(npub);
-      
-      if (result.success) {
-        message.success(`NPUB removed from ${type} list successfully`);
-        await fetchNpubs(page); // Refresh current page
-      } else {
-        throw new Error(result.message);
-      }
+      await addAllowedUser({ npub, tier });
+      message.success('User added successfully');
+      // Refresh the list
+      await fetchUsers(pagination.page, pagination.page_size);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : `Failed to remove NPUB from ${type} list`;
+      const errorMessage = err instanceof Error ? err.message : 'Failed to add user';
+      setError(errorMessage);
       message.error(errorMessage);
+      throw err;
     } finally {
       setLoading(false);
     }
-  }, [type, page, fetchNpubs]);
+  }, [fetchUsers, pagination.page, pagination.page_size]);
 
-  const bulkImport = useCallback(async (npubsData: string[]) => {
+  const removeUser = useCallback(async (npub: string) => {
     setLoading(true);
+    setError(null);
     try {
-      const importData: BulkImportRequest = {
-        type,
-        npubs: npubsData
-      };
-      
-      const result = await bulkImportNpubs(importData);
-      if (result.success) {
-        message.success(`Bulk import completed: ${result.imported} imported, ${result.failed} failed`);
-        await fetchNpubs(1); // Refresh the list
-      } else {
-        throw new Error(result.message);
-      }
+      await removeAllowedUser({ npub });
+      message.success('User removed successfully');
+      // Refresh the list
+      await fetchUsers(pagination.page, pagination.page_size);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Bulk import failed';
+      const errorMessage = err instanceof Error ? err.message : 'Failed to remove user';
+      setError(errorMessage);
       message.error(errorMessage);
+      throw err;
     } finally {
       setLoading(false);
     }
-  }, [type, fetchNpubs]);
-
-  const changePage = useCallback((newPage: number) => {
-    setPage(newPage);
-    fetchNpubs(newPage);
-  }, [fetchNpubs]);
+  }, [fetchUsers, pagination.page, pagination.page_size]);
 
   useEffect(() => {
-    fetchNpubs();
-  }, [fetchNpubs]);
+    fetchUsers();
+  }, [fetchUsers]);
 
   return {
-    npubs,
-    total,
+    users,
     loading,
     error,
-    page,
-    pageSize,
-    addNpub,
-    removeNpub,
-    bulkImport,
-    changePage,
-    refetch: fetchNpubs
+    pagination,
+    addUser,
+    removeUser,
+    refetch: fetchUsers
+  };
+};
+
+// Legacy hook for backward compatibility - will be removed
+export const useAllowedUsersNpubs = (type: 'read' | 'write') => {
+  const { users, loading, error, addUser, removeUser, refetch } = useAllowedUsersList();
+  
+  return {
+    npubs: users,
+    loading,
+    error,
+    addNpub: addUser,
+    removeNpub: removeUser,
+    refetch
   };
 };
 
 // Validation hook
 export const useAllowedUsersValidation = () => {
-  const validateSettings = useCallback((settings: AllowedUsersSettings): string[] => {
-    const errors: string[] = [];
-    
-    // Mode validation
-    if (!['free', 'paid', 'exclusive'].includes(settings.mode)) {
-      errors.push('Invalid mode selected');
-    }
-    
-    // Tier validation
-    if (settings.mode === 'paid' && settings.tiers.some(t => t.price_sats === 0)) {
-      errors.push('Paid mode cannot have free tiers');
-    }
-    
-    // Scope validation
-    if (settings.mode === 'paid' && settings.write_access.scope !== 'paid_users') {
-      errors.push('Paid mode write access must be limited to paid users');
-    }
-    
-    if (settings.mode === 'exclusive' && settings.write_access.scope !== 'allowed_users') {
-      errors.push('Exclusive mode write access must be limited to allowed users');
-    }
-    
-    // Tiers validation
-    if (settings.tiers.length === 0) {
-      errors.push('At least one tier must be configured');
-    }
-    
-    return errors;
-  }, []);
-
   const validateNpub = useCallback((npub: string): string | null => {
-    if (!npub.trim()) {
-      return 'NPUB cannot be empty';
+    if (!npub) {
+      return 'NPUB is required';
     }
     
     if (!npub.startsWith('npub1')) {
@@ -266,11 +179,30 @@ export const useAllowedUsersValidation = () => {
       return 'NPUB must be 63 characters long';
     }
     
+    // Basic bech32 validation
+    const validChars = /^[a-z0-9]+$/;
+    const npubWithoutPrefix = npub.slice(5);
+    if (!validChars.test(npubWithoutPrefix)) {
+      return 'NPUB contains invalid characters';
+    }
+    
     return null;
   }, []);
 
   return {
-    validateSettings,
     validateNpub
+  };
+};
+
+// Main hook that combines settings and users
+export const useAllowedUsers = () => {
+  const settingsHook = useAllowedUsersSettings();
+  const usersHook = useAllowedUsersList();
+  const validation = useAllowedUsersValidation();
+
+  return {
+    ...settingsHook,
+    ...usersHook,
+    ...validation
   };
 };

--- a/src/store/slices/allowedUsersSlice.ts
+++ b/src/store/slices/allowedUsersSlice.ts
@@ -1,18 +1,16 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { AllowedUsersSettings, AllowedUsersNpub } from '@app/types/allowedUsers.types';
+import { AllowedUsersSettings, AllowedUser } from '@app/types/allowedUsers.types';
 
 interface AllowedUsersState {
   settings: AllowedUsersSettings | null;
-  readNpubs: AllowedUsersNpub[];
-  writeNpubs: AllowedUsersNpub[];
+  users: AllowedUser[];
   loading: boolean;
   error: string | null;
 }
 
 const initialState: AllowedUsersState = {
   settings: null,
-  readNpubs: [],
-  writeNpubs: [],
+  users: [],
   loading: false,
   error: null,
 };
@@ -30,28 +28,24 @@ const allowedUsersSlice = createSlice({
     setSettings: (state, action: PayloadAction<AllowedUsersSettings>) => {
       state.settings = action.payload;
     },
-    setReadNpubs: (state, action: PayloadAction<AllowedUsersNpub[]>) => {
-      state.readNpubs = action.payload;
+    setUsers: (state, action: PayloadAction<AllowedUser[]>) => {
+      state.users = action.payload;
     },
-    setWriteNpubs: (state, action: PayloadAction<AllowedUsersNpub[]>) => {
-      state.writeNpubs = action.payload;
+    addUser: (state, action: PayloadAction<AllowedUser>) => {
+      state.users.push(action.payload);
     },
-    addReadNpub: (state, action: PayloadAction<AllowedUsersNpub>) => {
-      state.readNpubs.push(action.payload);
+    removeUser: (state, action: PayloadAction<string>) => {
+      state.users = state.users.filter(user => user.npub !== action.payload);
     },
-    addWriteNpub: (state, action: PayloadAction<AllowedUsersNpub>) => {
-      state.writeNpubs.push(action.payload);
-    },
-    removeReadNpub: (state, action: PayloadAction<string>) => {
-      state.readNpubs = state.readNpubs.filter(npub => npub.npub !== action.payload);
-    },
-    removeWriteNpub: (state, action: PayloadAction<string>) => {
-      state.writeNpubs = state.writeNpubs.filter(npub => npub.npub !== action.payload);
+    updateUser: (state, action: PayloadAction<{ npub: string; updates: Partial<AllowedUser> }>) => {
+      const index = state.users.findIndex(user => user.npub === action.payload.npub);
+      if (index !== -1) {
+        state.users[index] = { ...state.users[index], ...action.payload.updates };
+      }
     },
     clearState: (state) => {
       state.settings = null;
-      state.readNpubs = [];
-      state.writeNpubs = [];
+      state.users = [];
       state.loading = false;
       state.error = null;
     },
@@ -62,12 +56,10 @@ export const {
   setLoading,
   setError,
   setSettings,
-  setReadNpubs,
-  setWriteNpubs,
-  addReadNpub,
-  addWriteNpub,
-  removeReadNpub,
-  removeWriteNpub,
+  setUsers,
+  addUser,
+  removeUser,
+  updateUser,
   clearState,
 } = allowedUsersSlice.actions;
 


### PR DESCRIPTION
# Backend API Migration and Personal Mode Implementation

  ## Summary

  This PR implements a complete migration to the new unified backend API structure and adds full support for **public**, **only-me**, and
  **invite-only** relay modes. The changes provide a robust foundation for the new access control system with proper NPUB handling and
  mode-specific UI flows.

  ## Key Features Implemented

  ### ✅ Public Mode
  - **Forced Permissions**: Automatically sets read/write to "all_users"
  - **UI Behavior**: Hides user management, shows tier configuration
  - **Default Tiers**: Basic (100MB), Standard (500MB), Plus (1GB)

  ### ✅ Only-Me Mode  
  - **Relay Owner Management**: Dedicated API endpoints for single owner
  - **NPUB Conversion**: Proper hex ↔ npub conversion using nip19
  - **Owner UI**: Clean interface for setting/updating/removing relay owner
  - **Forced Permissions**: Write locked to "only_me", read configurable

  ### ✅ Invite-Only Mode
  - **User Management**: Add/remove users with tier assignment
  - **Pagination**: Support for large user lists (20 users per page)
  - **Forced Permissions**: Write locked to "allowed_users", read configurable  
  - **Default Tiers**: Member (5GB), VIP (50GB), Unlimited

  ## Technical Changes

  ### API Migration
  - **Unified Endpoints**: Migrated from separate read/write APIs to unified user management
  - **REST Compliance**: Proper HTTP methods (GET, POST, DELETE)
  - **NPUB Support**: Full bech32 encoding/decoding with nostr-tools
  - **Error Handling**: Comprehensive logging and user feedback

  ### Type System Updates
  - **New Mode Types**: `'only-me' | 'invite-only' | 'public' | 'subscription'`
  - **Permission Types**: `'all_users' | 'paid_users' | 'allowed_users' | 'only_me'`
  - **Unified User Model**: Single `AllowedUser` interface replacing separate read/write models
  - **Mode Configurations**: Automatic permission validation and enforcement

  ### UI Components
  - **Mode Selector**: Updated 2x2 grid with proper mode descriptions
  - **Permissions Config**: Dynamic UI based on mode with forced permission indicators
  - **Relay Owner Config**: New component for only-me mode owner management
  - **User Management**: Enhanced table with tier assignment and pagination

  ## Backend Integration Status

  | Mode | Frontend Status | Backend Status | Notes |
  |------|----------------|----------------|-------|
  | **Public** | ✅ Complete | ✅ Working | Fully functional |
  | **Only-Me** | ✅ Complete | ✅ Working | Uses `/api/admin/owner` endpoints |
  | **Invite-Only** | ✅ Complete | ⏳ Pending | Waiting for `/api/allowed/add` and `/api/allowed/remove` |
  | **Subscription** | ⏳ Future | ⏳ Future | Next phase |

  ## Files Changed

  ### Core API
  - `src/api/allowedUsers.api.ts` - Complete rewrite for new backend structure
  - `src/types/allowedUsers.types.ts` - Updated types and mode configurations

  ### Components
  - `src/components/allowed-users/components/ModeSelector/` - Updated mode names and descriptions
  - `src/components/allowed-users/components/PermissionsConfig/` - Mode-based permission enforcement  
  - `src/components/allowed-users/components/NPubManagement/` - Unified user management
  - `src/components/allowed-users/components/RelayOwnerConfig/` - **New** - Owner management for only-me mode
  - `src/components/allowed-users/layouts/AllowedUsersLayout.tsx` - Conditional UI rendering

  ### State Management
  - `src/hooks/useAllowedUsers.ts` - Updated hooks for new API structure
  - `src/store/slices/allowedUsersSlice.ts` - State management updates

  ## Testing Notes

  ### What Works Now
  - ✅ **Public Mode**: Switch to public mode, save settings
  - ✅ **Only-Me Mode**: Set relay owner, update owner, remove owner  
  - ✅ **Mode Transitions**: Automatic permission enforcement when switching modes
  - ✅ **NPUB Validation**: Proper format validation and conversion

  ### What Needs Backend Support
  - ⏳ **Invite-Only User Management**: Adding/removing users (endpoints not implemented)
  - ⏳ **User List Loading**: Getting paginated user lists (endpoint not implemented)

  ## Migration Notes

  ### Breaking Changes
  - **API Endpoints**: Old read/write endpoints no longer used
  - **Data Structure**: User permissions now tier-based instead of boolean flags
  - **Mode Names**: Updated from `personal/exclusive/free/paid` to `only-me/invite-only/public/subscription`
