### PR TITLE
Fix "Unconfirmed Transactions Cut Off"

### DIFF
--- a/src/components/relay-dashboard/unconfirmed-transactions/components/Modal/UnconfirmedTxModal.tsx
+++ b/src/components/relay-dashboard/unconfirmed-transactions/components/Modal/UnconfirmedTxModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import * as S from './UnconfirmedTxModal.styles';
 import UnconfirmedTransactions from '../../UnconfirmedTransactions';
 
@@ -8,10 +9,11 @@ interface UnconfirmedTxModalProps {
 }
 
 const UnconfirmedTxModal: React.FC<UnconfirmedTxModalProps> = ({ isOpen, onOpenChange }) => {
-  return (
+  return ReactDOM.createPortal(
     <S.Modal open={isOpen} centered={true} onCancel={onOpenChange} footer={null} destroyOnClose>
       <UnconfirmedTransactions />
-    </S.Modal>
+    </S.Modal>,
+    document.body
   );
 };
 


### PR DESCRIPTION
<img width="1110" height="505" alt="Screenshot 2025-07-19 at 10 14 19 PM" src="https://github.com/user-attachments/assets/633580f1-dae2-4219-82df-adc9ea19ca70" />

Starting with simple fix for a first PR.

The unconfirmed transaction modal was being clipped under by the left sidebar.

Due to the document nested hierarchy, simply setting a high z-index wouldn't cause the modal to appear above the rest of the content. Removing the z-index on the sidebar component would have fixed this issue, but didn't change that to reduce the possibility of introducing edge cases in other parts of the UI.

The solution used here is to use react-dom `createPortal` to place the component in the root level of the document body. This correctly places the modal above the rest of the content, keeping code changes to this issue localized to the component itself.